### PR TITLE
Temporary Bug Fix

### DIFF
--- a/src/apollomacros.h
+++ b/src/apollomacros.h
@@ -30,7 +30,7 @@
 #define SSID_SIZE 32
 #define PASSPHRASE_SIZE 32
 #define DEVICEID_SIZE 32
-#define APIKEY_SIZE 32
+#define APIKEY_SIZE 35
 #define TOKEN_SIZE 512
 #define IP_SIZE 16
 #define FINGERPRINT_SIZE 256


### PR DESCRIPTION
The apiKey was usually 25 characters long with the recent update (we prefixed the key with grandeur) it is now 32 characters long which is (somehow) trimming the last character before sending it to server. So I have temporarily added a fix by increasing the apiKey default size.